### PR TITLE
Add link to qtcreator setup wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,25 @@ A launcher for the reMarkable tablet, which wraps around the standard interface.
 
 (nb. You fiddle with the internal system of your reMarkable at your own risk! Here be dragons.)
 
-### 1. Deploy draft
+### 1. Setup QT Creator
+To build draft you'll need to first set up QT Creator, which is covered on the [reMarkable wiki](https://remarkablewiki.com/devel/qt_creator).
+
+### 2. Deploy draft
 This should simply be a case of opening up qtcreator, loading up the project with the normal reMarkable target, and hitting "run".
 
 As well as deploying the program, this will also populate `/etc/draft` with some sample commands and add a `/lib/systemd/system/draft.service` systemd file.
 
 
-### 1.i (optional) Deploy button-capture
+### 2.i (optional) Deploy button-capture
 
 [This small program](https://github.com/dixonary/button-capture-reMarkable) allows you to close the current application and return to the draft launcher. There is no native way to close `xochitl` so this is a very useful thing to have if you want to switch between applications. 
 
 
-### 1.ii (optional) Deploy fingerterm
+### 2.ii (optional) Deploy fingerterm
 
 [This terminal](https://github.com/dixonary/fingerterm-reMarkable) runs on the reMarkable and lets you change some config things without needing to SSH in! It's one of the default config options but you can remove that if you are't wanting to use it.
 
-### 2. Enable at startup
+### 3. Enable at startup
 You need to replace the normal xochitl startup with draft. This is done with the following two lines via SSH:
 
 ```bash
@@ -34,11 +37,11 @@ systemctl disable xochitl
 systemctl enable draft
 ```
 
-### 3. Restart your reMarkable
+### 4. Restart your reMarkable
 
 On restart you should find that `xochitl`, `fingerterm` and `shutdown` are your available choices and the draft launcher is running.
 
-### 4. Configure draft
+### 5. Configure draft
 
 Draft is configured through the files in the `/etc/draft` directory. They consist of a few simple lines. All of them are needed otherwise the option will not show up in the launcher.
 


### PR DESCRIPTION
This is helpful for people coming in with no knowledge of developing for the reMarkable and just want to install draft.