### PR TITLE
QTCreator-less build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,26 @@ A launcher for the reMarkable tablet, which wraps around the standard interface.
 
 [Draft v0.2 video](https://www.youtube.com/watch?v=VEngMK54SV4)
 
+- [QT Creator Set-up](#qt-creator-set-up)
+  * [1. Setup QT Creator](#1-setup-qt-creator)
+  * [2. Deploy draft](#2-deploy-draft)
+    + [2.i (optional) Deploy button-capture](#2i--optional--deploy-button-capture)
+    + [2.ii (optional) Deploy fingerterm](#2ii--optional--deploy-fingerterm)
+  * [3. Enable at startup](#3-enable-at-startup)
+  * [4. Restart your reMarkable](#4-restart-your-remarkable)
+- [Build setup without QT Creator](#build-setup-without-qt-creator)
+  * [1. Download and install](#1-download-and-install)
+  * [2. Activate environment](#2-activate-environment)
+  * [3. Build](#3-build)
+  * [4. Deploy](#4-deploy)
+- [Configure draft](#configure-draft)
+
+
 * * *
 
 ## QT Creator Set-up
 
-**This information is quite vague. Reddit user /u/prpletentacle wrote up their process for setting up Draft+rM, with the Plato app, here: https://www.reddit.com/r/RemarkableTablet/comments/bkbps9/how_to_install_plato_reader_and_add_it_to_draft/?st=jvp0mqus&sh=0651e353**
+This information is quite vague. Reddit user /u/prpletentacle wrote up their process for setting up Draft+rM, with the Plato app, here: https://www.reddit.com/r/RemarkableTablet/comments/bkbps9/how_to_install_plato_reader_and_add_it_to_draft/?st=jvp0mqus&sh=0651e353
 
 (nb. You fiddle with the internal system of your reMarkable at your own risk! Here be dragons.)
 
@@ -20,12 +35,12 @@ This should simply be a case of opening up qtcreator, loading up the project wit
 As well as deploying the program, this will also populate `/etc/draft` with some sample commands and add a `/lib/systemd/system/draft.service` systemd file.
 
 
-### 2.i (optional) Deploy button-capture
+#### 2.i (optional) Deploy button-capture
 
 [This small program](https://github.com/dixonary/button-capture-reMarkable) allows you to close the current application and return to the draft launcher. There is no native way to close `xochitl` so this is a very useful thing to have if you want to switch between applications. 
 
 
-### 2.ii (optional) Deploy fingerterm
+#### 2.ii (optional) Deploy fingerterm
 
 [This terminal](https://github.com/dixonary/fingerterm-reMarkable) runs on the reMarkable and lets you change some config things without needing to SSH in! It's one of the default config options but you can remove that if you are't wanting to use it.
 
@@ -41,21 +56,8 @@ systemctl enable draft
 
 On restart you should find that `xochitl`, `fingerterm` and `shutdown` are your available choices and the draft launcher is running.
 
-### 5. Configure draft
 
-Draft is configured through the files in the `/etc/draft` directory. They consist of a few simple lines. All of them are needed otherwise the option will not show up in the launcher.
-
-`title`: Big word, left hand side of the screen.
-
-`desc`: Smaller words, left hand side of the screen.
-
-`call`: The shell command to run when the option is pressed.
-
-`term`: The shell command to run while the option is running, to close it. (or it can do whatever you want really!) This won't do anything without `button-capture` installed.
-
-`imgFile`: An icon to use. It will look for a PNG image with that name in the `/etc/draft/icons` directory.
-
-*NOTE: Be sure not to leave any spaces around the "=" sign in the config lines, else the files may not parse correctly and your options may not show up!*
+* * * 
 
 ## Build setup without QT Creator
 
@@ -66,7 +68,8 @@ These steps should help you automate a build setup. This way:
 
 Note: NixOS has a package called [remarkable-toolchain](https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/tools/misc/remarkable/remarkable-toolchain) in the unstable channel (aka not in 20.03 stock) that lets you skip the first step (although it doesn't give you a .nix-shell and you need to know where to find the files for step 2).
 
-1. Download and install:
+### 1. Download and install
+
 ```
 $ (ensure prereqs exist: python, libarchive, file, )
 $ mkdir rm-toolchain
@@ -76,7 +79,8 @@ $ ./install-toolchain -D -y -d rm-toolchain
 `-D` turns on set -x for the script (bash print debugging); `-y` says yes to everything; `-d` tells it where to install.
 This file is a shell script with an embedded tar archive.  The script unpacks the archive and then edits shell scripts to contain the correct paths based on where you've installed it.
 
-2. Activate environment:
+### 2. Activate environment
+
 The installed toolchain contains a [sysroot](https://doc.qt.io/qt-5/configure-linux-device.html), a package of binaries for cross compiling and some compiler/qt related environment variables setup by some shell scripts. There's probably plenty of redundant stuff here too.
 
 Activate:
@@ -89,7 +93,7 @@ Running `env` should yield a bunch of variables and a path that looks through th
 
 The next step will need to be run in the same terminal session to preserve env variables.
 
-3. Build
+### 3. Build
 
 ```
 $ git clone https://www.github.com/dixionary/draft-reMarkable
@@ -108,13 +112,31 @@ make
 ```
 Again you can run `file src/frontend/mosh-client` to ensure it's an ARM binary that was produced.
 
-4. Deploy
+### 4. Deploy
+
 Unfortunately this is the one step I had to do manually. QT Creator uses draft.pro to build and then package and deploy the app onto the device. Without the IDE, draft will need the reMarkable to have the files placed according to the steps found in [draft.pro]:
 * `draft` binary goes in /usr/bin
 * `mkdir -p /usr/share/draft/qml; mkdir -p /usr/share/draft js` all of the files in the `qml/` and `js/` directories should go into these folders
-* Copy `extra-files/draft/` into `/etc/` so `/etc/draft/01-xochitl` etc exist. These are the files that define which apps to run and how, in addition to icons.
+* Copy `extra-files/draft/` into `/etc/` so `/etc/draft/01-xochitl` etc exist. These are the files that define which apps to run and how, in addition to icons (see above for full details).
 * Copy `extra-files/draft.service` to `/lib/systemd/system/draft.service` to install the systemd file. This will install
   draft as a system service. Then you'll need to `systemctl disable xochitl && systemctl enable draft` to replace
 `xochitl` with `draft` as the startup app. Reboot, or to see it take effect right away, do `systemctl stop xochitl && systemctl start draft`.
 
 You can view debug logs for draft and any app that draft tries to launch by running `journalctl -fu draft`.
+
+* * * 
+## Configure draft
+
+Draft is configured through the files in the `/etc/draft` directory. They consist of a few simple lines. All of them are needed otherwise the option will not show up in the launcher.
+
+`title`: Big word, left hand side of the screen.
+
+`desc`: Smaller words, left hand side of the screen.
+
+`call`: The shell command to run when the option is pressed.
+
+`term`: The shell command to run while the option is running, to close it. (or it can do whatever you want really!) This won't do anything without `button-capture` installed.
+
+`imgFile`: An icon to use. It will look for a PNG image with that name in the `/etc/draft/icons` directory.
+
+*NOTE: Be sure not to leave any spaces around the "=" sign in the config lines, else the files may not parse correctly and your options may not show up!*


### PR DESCRIPTION
I didn't want to install with a gui so I got cross-compilation working with just the toolchain and some basic dependencies. It should help with automating the build. Unfortunately deploying is not automated yet, but this seems pretty trivial to do (and this may fit better into https://github.com/dixonary/draft-reMarkable/pull/9)

Adds a table of contents too.